### PR TITLE
fix: set fortifyHeaders default to add all headers and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can choose to use these defaults by setting the fortify header to an empty o
 ```javascript
 import { fortifyHeaders, FortifySettings } from '@side/fortifyjs';
 
-const headers = fortifyHeaders({});
+const headers = fortifyHeaders();
 
 /** @type {FortifySettings} */
 console.log(headers); // same as above
@@ -142,6 +142,41 @@ console.log(headers); // same as above
  * {
       'Content-Security-Policy':
         "default-src 'self'; base-uri 'self'; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests",
+    }
+ */
+```
+
+If you want to specify a custom header value for one, like `Content-Security-Policy`, but also want to include all of the default headers, then you can use the second parameter to `fortifyHeaders` to tell the header generation that you want to include the rest of the available headers:
+
+```javascript
+import { fortifyHeaders, FortifySettings } from '@side/fortifyjs';
+
+const headers = fortifyHeaders(
+  {
+    contentSecurityPolicy: {
+      defaultSrc: ["'self'", '*.somedomain.com'],
+    },
+  },
+  { useDefaults: true },
+);
+
+/** @type {FortifySettings} */
+console.log(headers); // same as above
+/*
+ * {
+      'Content-Security-Policy': "default-src 'self' *.somedomain.com",
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+      'Expect-Ct': 'max-age=0',
+      'Origin-Agent-Cluster': '?1',
+      'Referrer-Policy': 'no-referrer',
+      'Strict-Transport-Security': 'max-age=15552000',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Dns-Prefetch-Control': 'off',
+      'X-Download-Options': 'noopen',
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-Permitted-Cross-Domain-Policies': 'none',
     }
  */
 ```

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -24,16 +24,19 @@ describe('fortify-core entrypoint tests', () => {
     });
 
     it('customizes some properties and defaults others', () => {
-      const fortifiedHeaders = fortifyHeaders({
-        contentSecurityPolicy: {},
-        crossOriginOpenerPolicy: {
-          unsafeNone: true,
+      const fortifiedHeaders = fortifyHeaders(
+        {
+          contentSecurityPolicy: {},
+          crossOriginOpenerPolicy: {
+            unsafeNone: true,
+          },
+          strictTransportSecurity: {
+            includeSubDomains: true,
+            maxAge: 6000000,
+          },
         },
-        strictTransportSecurity: {
-          includeSubDomains: true,
-          maxAge: 6000000,
-        },
-      });
+        { useDefaults: false },
+      );
 
       expect(fortifiedHeaders).toEqual({
         'Content-Security-Policy':

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -24,19 +24,16 @@ describe('fortify-core entrypoint tests', () => {
     });
 
     it('customizes some properties and defaults others', () => {
-      const fortifiedHeaders = fortifyHeaders(
-        {
-          contentSecurityPolicy: {},
-          crossOriginOpenerPolicy: {
-            unsafeNone: true,
-          },
-          strictTransportSecurity: {
-            includeSubDomains: true,
-            maxAge: 6000000,
-          },
+      const fortifiedHeaders = fortifyHeaders({
+        contentSecurityPolicy: {},
+        crossOriginOpenerPolicy: {
+          unsafeNone: true,
         },
-        { useDefaults: false },
-      );
+        strictTransportSecurity: {
+          includeSubDomains: true,
+          maxAge: 6000000,
+        },
+      });
 
       expect(fortifiedHeaders).toEqual({
         'Content-Security-Policy':

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -23,6 +23,27 @@ describe('fortify-core entrypoint tests', () => {
       });
     });
 
+    it('implicitly defaults with no parameters', () => {
+      const fortifiedHeaders = fortifyHeaders();
+
+      expect(fortifiedHeaders).toEqual({
+        'Content-Security-Policy':
+          "default-src 'self'; base-uri 'self'; font-src 'self' https: data:; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests",
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Resource-Policy': 'same-origin',
+        'Expect-Ct': 'max-age=0',
+        'Origin-Agent-Cluster': '?1',
+        'Referrer-Policy': 'no-referrer',
+        'Strict-Transport-Security': 'max-age=15552000',
+        'X-Content-Type-Options': 'nosniff',
+        'X-Dns-Prefetch-Control': 'off',
+        'X-Download-Options': 'noopen',
+        'X-Frame-Options': 'SAMEORIGIN',
+        'X-Permitted-Cross-Domain-Policies': 'none',
+      });
+    });
+
     it('customizes some properties and defaults others', () => {
       const fortifiedHeaders = fortifyHeaders({
         contentSecurityPolicy: {},

--- a/src/fortifyHeaders.ts
+++ b/src/fortifyHeaders.ts
@@ -29,13 +29,15 @@ function getConfig(
  * The primary entrypoint for generating HTTP security headers
  */
 export function fortifyHeaders(
-  settings: FortifySettings,
+  settings: FortifySettings = {},
   options: GenerationOptions = { useDefaults: false },
 ): FortifyHeaders {
   const availableHeaders = getAllHeaders();
-  const headerConfig = options.useDefaults
-    ? getConfig(availableHeaders, settings)
-    : settings;
+  const isEmpty = !Object.keys(settings).length;
+  const headerConfig =
+    options.useDefaults || isEmpty
+      ? getConfig(availableHeaders, settings)
+      : settings;
   return Object.keys(headerConfig).reduce<FortifyHeaders>(
     (acc: FortifyHeaders, cur) => {
       const directiveValues = headerConfig[cur];

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type FortifySettings = { [key: string]: object | boolean } & {
  * Represents higher-order options for header config generation
  */
 export type GenerationOptions = {
+
   /**
    * Directs FortifyJS to opt in or out of defaults
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,6 @@ export type FortifySettings = { [key: string]: object | boolean } & {
  * Represents higher-order options for header config generation
  */
 export type GenerationOptions = {
-
   /**
    * Directs FortifyJS to opt in or out of defaults
    */


### PR DESCRIPTION
While adding documentation for the new design in default enforcement, one use-case left out was if no parameters are used when invoking `fortifyHeaders`. In other words, there is no default functionality. This PR, while adding documentation on the `GenerationOptions` in the README, I've added the default functionality to implicitly tell the header generation to add all the available headers.