### PR TITLE
feat: add X-Robots-Tag header

### DIFF
--- a/src/__tests__/headers/get-all-headers.test.ts
+++ b/src/__tests__/headers/get-all-headers.test.ts
@@ -18,6 +18,7 @@ describe('tests for get-all-headers', () => {
       'xDownloadOptions',
       'xFrameOptions',
       'xPermittedCrossDomainPolicies',
+      'xRobotsTag',
     ]);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -21,6 +21,7 @@ describe('fortify-core entrypoint tests', () => {
         'X-Download-Options': 'noopen',
         'X-Frame-Options': 'SAMEORIGIN',
         'X-Permitted-Cross-Domain-Policies': 'none',
+        'X-Robots-Tag': 'noindex, nofollow, nosnippet, noarchive',
       });
     });
 
@@ -42,6 +43,7 @@ describe('fortify-core entrypoint tests', () => {
         'X-Download-Options': 'noopen',
         'X-Frame-Options': 'SAMEORIGIN',
         'X-Permitted-Cross-Domain-Policies': 'none',
+        'X-Robots-Tag': 'noindex, nofollow, nosnippet, noarchive',
       });
     });
 
@@ -94,6 +96,7 @@ describe('fortify-core entrypoint tests', () => {
         'X-Download-Options': 'noopen',
         'X-Frame-Options': 'SAMEORIGIN',
         'X-Permitted-Cross-Domain-Policies': 'none',
+        'X-Robots-Tag': 'noindex, nofollow, nosnippet, noarchive',
       });
     });
   });

--- a/src/headers/index.ts
+++ b/src/headers/index.ts
@@ -12,6 +12,7 @@ import { xDnsPrefetchControl } from './x-dns-prefetch-control';
 import { xDownloadOptions } from './x-download-options';
 import { xFrameOptions } from './x-frame-options';
 import { xPermittedCrossDomainPolicies } from './x-permitted-cross-domain-poilicies';
+import { xRobotsTag } from './x-robots-tag';
 
 /**
  * Returns an object with all the available fortifiable headers
@@ -31,5 +32,6 @@ export function getAllHeaders(): Record<string, HeaderFunction> {
     xDownloadOptions,
     xFrameOptions,
     xPermittedCrossDomainPolicies,
+    xRobotsTag,
   };
 }

--- a/src/headers/x-robots-tag/index.ts
+++ b/src/headers/x-robots-tag/index.ts
@@ -1,0 +1,41 @@
+import { applyDefaultsIfNecessary } from '../../directives/defaults';
+import type { XRobotsTag } from './types';
+
+const HEADER_NAME = 'X-Robots-Tag';
+
+const ALLOWED_DIRECTIVES = new Set([
+  'noindex',
+  'nofollow',
+  'nosnippet',
+  'noarchive',
+  'noimageindex',
+  'notranslate',
+]);
+
+/**
+ * Generates the X-Robots-Tag header and returns it in an object to the caller.
+ * Defaults to noindex, nofollow, nosnippet, noarchive.
+ */
+export function xRobotsTag(settings: XRobotsTag) {
+  const headerConfig = applyDefaultsIfNecessary(settings, {
+    noindex: true,
+    nofollow: true,
+    nosnippet: true,
+    noarchive: true,
+  });
+
+  const directives = Object.entries(headerConfig)
+    .filter(([key, value]) => {
+      if (!ALLOWED_DIRECTIVES.has(key)) {
+        throw new Error(
+          `${HEADER_NAME} does not support "${key}". It is not in the specification.`,
+        );
+      }
+      return value === true;
+    })
+    .map(([key]) => key);
+
+  return {
+    [HEADER_NAME]: directives.join(', '),
+  };
+}

--- a/src/headers/x-robots-tag/types.ts
+++ b/src/headers/x-robots-tag/types.ts
@@ -1,0 +1,32 @@
+import type { FortifyHeader } from '../types';
+
+/**
+ * Represents the user-specified header configuration for X-Robots-Tag
+ * see: https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag
+ */
+export type XRobotsTag = FortifyHeader & {
+  /**
+   * Do not show this page in search results
+   */
+  noindex?: boolean;
+  /**
+   * Do not follow the links on this page
+   */
+  nofollow?: boolean;
+  /**
+   * Do not show a text snippet or video preview in search results. A static image thumbnail may still be visible.
+   */
+  nosnippet?: boolean;
+  /**
+   * Do not show a cached link in search results
+   */
+  noarchive?: boolean;
+  /**
+   * Do not index images on this page
+   */
+  noimageindex?: boolean;
+  /**
+   * Do not offer translation of this page in search results
+   */
+  notranslate?: boolean;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export type { XDnsPrefetchControl } from './headers/x-dns-prefetch-control/types
 export type { XDownloadOptions } from './headers/x-download-options/types';
 export type { XFrameOptions } from './headers/x-frame-options/types';
 export type { XPermittedCrossDomainPolicies } from './headers/x-permitted-cross-domain-poilicies/types';
+export type { XRobotsTag } from './headers/x-robots-tag/types';
 export type { FortifySettings } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import type { XDnsPrefetchControl } from './headers/x-dns-prefetch-control/types
 import type { XDownloadOptions } from './headers/x-download-options/types';
 import type { XFrameOptions } from './headers/x-frame-options/types';
 import type { XPermittedCrossDomainPolicies } from './headers/x-permitted-cross-domain-poilicies/types';
+import type { XRobotsTag } from './headers/x-robots-tag/types';
 
 /**
  * Represents the primary configuration for FortifyJS
@@ -69,6 +70,10 @@ export type FortifySettings = { [key: string]: FortifyHeader | boolean } & {
    * Configuration for X-Permitted-Cross-Domain-Policies
    */
   xPermittedCrossDomainPolicies?: XPermittedCrossDomainPolicies | boolean;
+  /**
+   * Configuration for X-Robots-Tag
+   */
+  xRobotsTag?: XRobotsTag | boolean;
 };
 
 /**
@@ -98,4 +103,5 @@ export type FortifyHeaders = { [key: string]: string } & {
   'X-Download-Options'?: string;
   'X-Frame-Options'?: string;
   'X-Permitted-Cross-Domain-Policies'?: string;
+  'X-Robots-Tag'?: string;
 };


### PR DESCRIPTION
## Summary
- Adds `X-Robots-Tag` as a new default security header with value `noindex, nofollow, nosnippet, noarchive`
- Prevents search engines from indexing, following links, caching, or showing snippets for pages served by fortifyjs consumers
- Supports 6 configurable directives: `noindex`, `nofollow`, `nosnippet`, `noarchive`, `noimageindex`, `notranslate`
- Consumers can opt out with `xRobotsTag: false`

## Context
Our UI apps were found indexed on Google. This was previously handled at the preview-lb (nginx) layer but needs to be applied at the application level across all consumers (next-tools, fastify-tools, apollo-tools).

## Downstream impact
All consumers using `useDefaults: true` (next-tools, fastify-tools, apollo-tools) will automatically include this header after bumping `@side/fortifyjs`. Tests in those repos will need updating to include the new header in expected output.

## Test plan
- [x] All 70 existing tests pass
- [x] New header included in default output assertions
- [x] `getAllHeaders()` test updated
- [ ] Bump version in next-tools, fastify-tools, apollo-tools and update their tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)