### PR TITLE
chore(yarn): add age-gate config mirroring renovate trusted-org policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 # Skip assigning dep updates (handled by Renovate)
 package.json
 yarn.lock
+
+# Require Devops approval for yarn config changes
+.yarnrc.yml @reside-eng/devops

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,16 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 14d
+
+npmPreapprovedPackages:
+  - "@side/*"
+  - "@google/*"
+  - "google-*"
+  - "@datadog/*"
+  - "next"
+  - "react"
+  - "react-dom"
+  - "@yarnpkg/cli"
+
 yarnPath: .yarn/releases/yarn-4.15.0.cjs


### PR DESCRIPTION
## Context

Yarn 4.15.0 enables [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate) by default at `1d`. Yesterday's batched `@side/*` releases hit this gate in core-service and broke six Renovate PRs (raised in https://top-agent.slack.com/archives/C0B5164BG5R/p1779999854258089).

This repo was in the original fan-out but its commit was blocked by a stale Yarn install-state in the working tree (husky's `yarn lint-staged` couldn't resolve). A clean `yarn install` resolved it — the hooks were never broken.

## Change

1. **`.yarnrc.yml`** — mirror Renovate's trusted-org age-gate policy ([renovate-config/default.json:58-69](https://github.com/reside-eng/renovate-config/blob/main/default.json#L58-L69)): `npmMinimalAgeGate: 14d` + `npmPreapprovedPackages` (`@side/*`, `@google/*`, `google-*`, `@datadog/*`, `next`, `react`, `react-dom`, `@yarnpkg/cli`).
2. **`.github/CODEOWNERS`** — require `@reside-eng/devops` approval for future `.yarnrc.yml` changes (uniform org-wide policy per Eddie's request).

## Pilot

Same change landed first in https://github.com/reside-eng/core-service/pull/6430.